### PR TITLE
Use customizable FileReader strategy

### DIFF
--- a/lib/solidus_importer.rb
+++ b/lib/solidus_importer.rb
@@ -16,6 +16,7 @@ require 'solidus_importer/configuration'
 require 'solidus_importer/engine'
 require 'solidus_importer/process_import'
 require 'solidus_importer/process_row'
+require 'solidus_importer/file_reader'
 
 module SolidusImporter
   class << self

--- a/lib/solidus_importer/configuration.rb
+++ b/lib/solidus_importer/configuration.rb
@@ -37,6 +37,8 @@ module SolidusImporter
       }
     }
 
+    preference :import_file_reader, :string, default: 'SolidusImporter::FileReader'
+
     def available_types
       solidus_importer.keys
     end

--- a/lib/solidus_importer/file_reader.rb
+++ b/lib/solidus_importer/file_reader.rb
@@ -1,0 +1,7 @@
+module SolidusImporter
+  class FileReader
+    def self.call(import)
+      File.read(import.file.path)
+    end
+  end
+end

--- a/lib/solidus_importer/process_import.rb
+++ b/lib/solidus_importer/process_import.rb
@@ -47,12 +47,12 @@ module SolidusImporter
     private
 
     def scan
-      data = CSV.parse(
-        File.read(@import.file.path),
-        headers: true,
-        encoding: 'UTF-8',
-        header_converters: ->(h) { h.strip }
-      )
+      file = ::SolidusImporter::Config.import_file_reader.constantize.call(@import)
+
+      data = CSV.parse(file,
+                       headers: true,
+                       encoding: 'UTF-8',
+                       header_converters: ->(h) { h.strip })
       prepare_rows(data)
     end
 


### PR DESCRIPTION
For projects that require a different method for reading the import file (say, from an external URL) this allows for easier customization than MonkeyPatching the `scan` method